### PR TITLE
WIP: Upgrade SDL_ttf with HarfBuzz support. Fix #12

### DIFF
--- a/app/src/main/cpp/Instead/CMakeLists.txt
+++ b/app/src/main/cpp/Instead/CMakeLists.txt
@@ -2,7 +2,8 @@
 set(INSTEAD_SRC_DIR Instead/src)
 
 include_directories( ${INSTEAD_SRC_DIR} ${INSTEAD_SRC_DIR}/instead ../Lua/Lua/src ${CMAKE_BINARY_DIR}/libiconv/libiconv/include
-        ../SDL2/SDL2/include ../SDL2_mixer/SDL2_mixer ../SDL2_image/SDL2_image ../SDL2_ttf/SDL2_ttf )
+        ../SDL2/SDL2/include ../SDL2_mixer/SDL2_mixer ../SDL2_image/SDL2_image ../SDL2_ttf/SDL2_ttf 
+        ../SDL2_ttf/SDL2_ttf/external/harfbuzz-2.3.1 ../SDL2_ttf/SDL2_ttf/external/harfbuzz-2.3.1/src )
 
 set( SOURCES
         "instead_launcher.c"
@@ -35,9 +36,10 @@ set( SOURCES
         "${INSTEAD_SRC_DIR}/SDL2_rotozoom.c"
         "${INSTEAD_SRC_DIR}/SDL_anigif.c"
         "${INSTEAD_SRC_DIR}/SDL_gfxBlitFunc.c"
-        "${INSTEAD_SRC_DIR}/noise1234.c" )
+        "${INSTEAD_SRC_DIR}/noise1234.c"
+        "${INSTEAD_SRC_DIR}/guniprops.c" )
 
-add_definitions( -DANDROID -DNOMAIN -D_USE_SDL -D_LOCAL_APPDATA -D_SDL_MOD_BUG -D_HAVE_ICONV )
+add_definitions( -DANDROID -DNOMAIN -D_USE_SDL -D_LOCAL_APPDATA -D_SDL_MOD_BUG -D_HAVE_ICONV -D_USE_HARFBUZZ)
 add_definitions( -DVERSION=\"3.3.2\" -DGAMES_PATH=\"./games/\" -DTHEME_PATH=\"./themes/\" -DLANG_PATH=\"./lang/\" -DSTEAD_PATH=\"./stead/\" )
 add_definitions( -DSDL_JAVA_PACKAGE_PATH=org_emunix_insteadlauncher )
 

--- a/app/src/main/cpp/SDL2_ttf/CMakeLists.txt
+++ b/app/src/main/cpp/SDL2_ttf/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Build FreeType
 #----------------
 
-set( FREETYPE_DIR "SDL2_ttf/external/freetype-2.9.1" )
+set( FREETYPE_DIR "SDL2_ttf/external/freetype-2.10.1" )
 
 set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DFT2_BUILD_LIBRARY -Os" )
 
@@ -57,13 +57,81 @@ add_library( freetype STATIC ${SOURCES} )
 
 
 #----------------
+# Build HarfBuzz
+#----------------
+
+set( HARFBUZZ_DIR "SDL2_ttf/external/harfbuzz-2.3.1" )
+
+#set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_CONFIG_H -fPIC" )
+#set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHB_NO_MT -DHAVE_OT -DHAVE_UCDN -fPIC" )
+add_definitions("-DHB_NO_MT -DHAVE_OT -DHAVE_UCDN -fPIC")
+
+include_directories( "${HARFBUZZ_DIR}/src/" )
+include_directories( "${HARFBUZZ_DIR}/src/hb-ucdn/" )
+
+set( SOURCES
+        "${HARFBUZZ_DIR}/src/hb-blob.cc"
+        "${HARFBUZZ_DIR}/src/hb-buffer-serialize.cc"
+        "${HARFBUZZ_DIR}/src/hb-face.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-tag.cc"
+        "${HARFBUZZ_DIR}/src/hb-buffer.cc"
+        "${HARFBUZZ_DIR}/src/hb-font.cc"
+        "${HARFBUZZ_DIR}/src/hb-common.cc"
+        "${HARFBUZZ_DIR}/src/hb-set.cc"
+        "${HARFBUZZ_DIR}/src/hb-shape-plan.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-font.cc"
+        "${HARFBUZZ_DIR}/src/hb-shaper.cc"
+        "${HARFBUZZ_DIR}/src/hb-unicode.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-shape.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-face.cc"
+        "${HARFBUZZ_DIR}/src/hb-shape.cc"
+        "${HARFBUZZ_DIR}/src/hb-static.cc"
+        "${HARFBUZZ_DIR}/src/hb-warning.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-shape-complex-default.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-layout.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-math.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-map.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-shape-complex-arabic.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-shape-complex-hangul.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-shape-complex-hebrew.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-shape-complex-indic.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-shape-complex-indic-table.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-shape-complex-khmer.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-shape-complex-myanmar.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-shape-complex-thai.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-shape-complex-use.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-shape-complex-use-table.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-shape-normalize.cc"
+        #"${HARFBUZZ_DIR}/src/hb-fallback-shape.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-shape-fallback.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-shape-complex-vowel-constraints.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-var.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-cff1-table.cc"
+        "${HARFBUZZ_DIR}/src/hb-ot-cff2-table.cc"
+        "${HARFBUZZ_DIR}/src/hb-ft.cc"
+        "${HARFBUZZ_DIR}/src/hb-ucdn.cc"
+        "${HARFBUZZ_DIR}/src/hb-ucdn/ucdn.c"
+        "${HARFBUZZ_DIR}/src/hb-aat-layout.cc"
+        "${HARFBUZZ_DIR}/src/hb-aat-map.cc" )
+
+add_library( harfbuzz STATIC ${SOURCES} )
+
+
+#----------------
 # Build SDL_ttf
 #----------------
 
+set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DTTF_USE_HARFBUZZ" )
+
 include_directories( SDL2_ttf/ ../SDL2/SDL2/include/ )
+
+#set(HB_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+#set(HB_HAVE_FREETYPE ON CACHE BOOL "" FORCE)
+#set(FT_WITH_HARFBUZZ ON CACHE BOOL "" FORCE)
 
 add_library( SDL2_ttf SHARED SDL2_ttf/SDL_ttf.c )
 
 target_link_libraries( SDL2_ttf
-                        SDL2
-                        freetype )
+                       SDL2
+                       freetype
+                       harfbuzz )


### PR DESCRIPTION
This PR contains my changes in order to compile instead-launcher-android with HarfBuzz support (adds RTL support to Instead). Part of #12, also related https://github.com/instead-hub/instead/pull/83.